### PR TITLE
Added Super text size button

### DIFF
--- a/packages/excalidraw/actions/actionProperties.tsx
+++ b/packages/excalidraw/actions/actionProperties.tsx
@@ -104,6 +104,7 @@ import {
   FontSizeMediumIcon,
   FontSizeLargeIcon,
   FontSizeExtraLargeIcon,
+  FontSizeSuperLargeIcon,
   EdgeSharpIcon,
   EdgeRoundIcon,
   TextAlignLeftIcon,
@@ -707,6 +708,12 @@ export const actionChangeFontSize = register({
             text: t("labels.veryLarge"),
             icon: FontSizeExtraLargeIcon,
             testId: "fontSize-veryLarge",
+          },
+          {
+            value: 44,
+            text: t("labels.superLarge"),
+            icon: FontSizeSuperLargeIcon,
+            testId: "fontSize-superLarge",
           },
         ]}
         value={getFormValue(

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -1490,6 +1490,37 @@ export const FontSizeExtraLargeIcon = createIcon(
   modifiedTablerIconProps,
 );
 
+export const FontSizeSuperLargeIcon = createIcon(
+  <>
+    {/* First X */}
+    <path
+      d="M1.667 3.333L8.333 16.667M8.333 3.333L1.667 16.667"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    {/* Second X */}
+    <path
+      d="M10 3.333L16.667 16.667M16.667 3.333L10 16.667"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    {/* L */}
+    <path
+      d="M19.167 3.333v13.334h6.666"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </>,
+  modifiedTablerIconProps,
+);
+
+
 export const fontSizeIcon = createIcon(
   <g strokeWidth={1.25}>
     <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -64,6 +64,7 @@
     "medium": "Medium",
     "large": "Large",
     "veryLarge": "Very large",
+    "superLarge" : "Super large",
     "solid": "Solid",
     "hachure": "Hachure",
     "zigzag": "Zigzag",


### PR DESCRIPTION
Navigated through the code to find text size attributes location as well as the left island menu location. Added a button that gives the user an even greater text size option and the corresponding code to render the button icon and logic.